### PR TITLE
Add notice to stdout and syslog on key refresh success

### DIFF
--- a/gen_wg_config.sh
+++ b/gen_wg_config.sh
@@ -120,6 +120,9 @@ wg_check_pubkey() {
         now=$(date -Iseconds --utc)
         if [ "${now}" '<' "${expire_date}" ];then
             register=0
+	printf '%b' "\n\n\tWG AUTHENTICATION KEY REFRESH\n\n    RUN DATE:   "${now}"\n\n"
+	printf '%b' " KEY EXPIRES:   "${expire_date}"\n\n"
+	logger -t SSWG "RUN DATE:${now}   KEYS EXPIRE ON: ${expire_date}"
         fi
     elif [ $http_status -eq 401 ]; then
         rm -f $token_file


### PR DESCRIPTION
Gives positive response of PubKey authentication refresh on `stdout` and `syslog` 

cli:
         WG AUTHENTICATION KEY REFRESH
        RUN DATE:   2022-04-27T11:32:24-04:00
  KEY EXPIRES:   2022-05-04T15:32:23+00:00

syslog:
`logread -e SSWG

Tue May  3 00:10:06 2022 user.notice SSWG: RUN DATE:2022-05-03T00:10:06-04:00   KEYS EXPIRE ON: 2022-05-10T04:10:05+00:00`
